### PR TITLE
Add support of optional metadata parameter. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ For example:
 
     # To specify a specific profile and property to the docker command.
     docker run --network="host" vasdvp/health-apis-conformance-unifier --spring.profiles.active=qa --bucket.name=qaresultbucket r4 smart-configuration https://api.va.gov/services/fhir/v0/r4/.well-known/smart-configuration
+
+    # The `--metadata` switch can be added one or more times to the parameter list containing a list of comma delimited `key=value` to associate with the generated S3 object.
+    docker run --network="host" vasdvp/health-apis-conformance-unifier --metadata=uc-app-version=1.0.0,claims-app-version=2.0.0 dstu2 smart-configuration https://api.va.gov/services/fhir/v0/dstu2/.well-known/smart-configuration
     ```
 
 4. You can use regular `aws` commands to see the resulting objects in the mock s3.  For example,
@@ -63,6 +66,9 @@ For example:
 
    # Copy the specified object to stdout (example showing r4-capability):
    aws s3 --endpoint-url http://localhost:9090 cp s3://testbucket/r4-capability -
+
+   # See the metadata for the specified object to stdout (example showing dstu-smart-configuration):
+   aws s3api get-object --bucket testbucket --endpoint-url http://localhost:9090 --key dstu2-smart-configuration /dev/null
    ``` 
 
 5. To Stop the docker:

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/Application.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/Application.java
@@ -1,11 +1,9 @@
 package gov.va.api.health.conformance.unifier;
 
-import gov.va.api.health.conformance.unifier.fhir.ResourceTypeEnum;
-import gov.va.api.health.conformance.unifier.fhir.dstu2.Dstu2UnifierService;
-import gov.va.api.health.conformance.unifier.fhir.r4.R4UnifierService;
-import gov.va.api.health.conformance.unifier.fhir.stu3.Stu3UnifierService;
 import gov.va.views.amazon.s3.AmazonS3ClientServiceConfig;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
@@ -20,14 +18,11 @@ import org.springframework.context.annotation.Import;
 @Slf4j
 public class Application implements ApplicationRunner {
 
-  /** DSTU2 unifier service. */
-  @Autowired Dstu2UnifierService dstu2UnifierService;
+  /** Optional argument to associate metadata with the generated S3 object. */
+  public static final String METADATA_ARG = "metadata";
 
-  /** STU3 unifier service. */
-  @Autowired Stu3UnifierService stu3UnifierService;
-
-  /** R4 unifier service. */
-  @Autowired R4UnifierService r4UnifierService;
+  /** Unifier service. */
+  @Autowired private UnifierService unifierService;
 
   /**
    * Main.
@@ -42,28 +37,37 @@ public class Application implements ApplicationRunner {
 
   @Override
   public void run(ApplicationArguments args) throws Exception {
+    // Check count of required non option args.
     List<String> argList = args.getNonOptionArgs();
     if (argList.size() < ArgEnum.values().length) {
       throw new IllegalArgumentException(
           "Invalid number of arguments.  Expected minimum count " + ArgEnum.values().length + ".");
     }
-    // Call appropriate unifier based on the resource type argument.
-    final String resourceType = argList.get(ArgEnum.RESOURCE.ordinal());
-    final String endpointType = argList.get(ArgEnum.ENDPOINT.ordinal());
-    final List<String> urlList = argList.subList(ArgEnum.URL.ordinal(), argList.size());
-    switch (ResourceTypeEnum.fromType(resourceType)) {
-      case R4:
-        r4UnifierService.unify(ResourceTypeEnum.R4, endpointType, urlList);
-        break;
-      case DSTU2:
-        dstu2UnifierService.unify(ResourceTypeEnum.DSTU2, endpointType, urlList);
-        break;
-      case STU3:
-        stu3UnifierService.unify(ResourceTypeEnum.STU3, endpointType, urlList);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported resource type: " + resourceType);
+
+    // Process option metadata arg.
+    // Arg may contain one or more key=value separated by comma.
+    final List<String> metadataValueList = args.getOptionValues(METADATA_ARG);
+    Map<String, String> metadataMap = new HashMap<>();
+    if (metadataValueList != null) {
+      try {
+        for (String metadataKeyValueString : metadataValueList) {
+          final String[] metadataKeyValueArray = metadataKeyValueString.split("\\s*,\\s*");
+          for (String keyValueString : metadataKeyValueArray) {
+            final String[] keyValuePair = keyValueString.split("=", 2);
+            metadataMap.put(keyValuePair[0], keyValuePair[1]);
+          }
+        }
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid metadata argument: " + e.getMessage());
+      }
     }
+
+    /** Call unifier service. */
+    unifierService.unify(
+        argList.get(ArgEnum.RESOURCE.ordinal()),
+        argList.get(ArgEnum.ENDPOINT.ordinal()),
+        argList.subList(ArgEnum.URL.ordinal(), argList.size()),
+        metadataMap);
   }
 
   /** Expected argument order. */

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/UnifierService.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/UnifierService.java
@@ -1,0 +1,58 @@
+package gov.va.api.health.conformance.unifier;
+
+import gov.va.api.health.conformance.unifier.fhir.ResourceTypeEnum;
+import gov.va.api.health.conformance.unifier.fhir.dstu2.Dstu2UnifierService;
+import gov.va.api.health.conformance.unifier.fhir.r4.R4UnifierService;
+import gov.va.api.health.conformance.unifier.fhir.stu3.Stu3UnifierService;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Unifier service that serves to route to appropriate resource specific unifier service based on
+ * the resource type parameter.
+ */
+@Service
+@RequiredArgsConstructor(onConstructor = @__({@Autowired}))
+public class UnifierService {
+
+  /** DSTU2 unifier service. */
+  private final Dstu2UnifierService dstu2UnifierService;
+
+  /** STU3 unifier service. */
+  private final Stu3UnifierService stu3UnifierService;
+
+  /** R4 unifier service. */
+  private final R4UnifierService r4UnifierService;
+
+  /**
+   * Unify the urlList of endpoint type.
+   *
+   * @param resourceType Type of resource.
+   * @param endpointType String representing requested type of endpoint.
+   * @param urlList List of URL to unify.
+   * @param metadataMap Map of metadata to associate with the generated S3 object.
+   */
+  public void unify(
+      final String resourceType,
+      final String endpointType,
+      final List<String> urlList,
+      Map<String, String> metadataMap) {
+    // Call appropriate unifier based on the resource type.
+    switch (ResourceTypeEnum.fromType(resourceType)) {
+      case R4:
+        r4UnifierService.unify(ResourceTypeEnum.R4, endpointType, urlList, metadataMap);
+        break;
+      case DSTU2:
+        dstu2UnifierService.unify(ResourceTypeEnum.DSTU2, endpointType, urlList, metadataMap);
+        break;
+      case STU3:
+        stu3UnifierService.unify(ResourceTypeEnum.STU3, endpointType, urlList, metadataMap);
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported resource type: " + resourceType);
+    }
+  }
+}

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/awss3/AmazonS3ClientWriterService.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/awss3/AmazonS3ClientWriterService.java
@@ -1,8 +1,13 @@
 package gov.va.api.health.conformance.unifier.awss3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.views.amazon.s3.AmazonS3ClientServiceInterface;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -16,6 +21,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AmazonS3ClientWriterService {
 
+  private static final String S3_OBJECT_CONTENT_TYPE = "plain/text";
+
+  private static final String S3_OBJECT_CUSTOM_METADATA_PREFIX = "x-amz-meta-";
+
   private final AmazonS3BucketConfig bucketConfig;
 
   @Setter private AmazonS3ClientServiceInterface s3ClientService;
@@ -24,10 +33,12 @@ public class AmazonS3ClientWriterService {
    * Write object to the Amazon S3 Bucket. Any exceptions with the interface will ripple up.
    *
    * @param key Name of object in bucket.
+   * @param metadataMap Map of metadata to associate with the generated S3 object.
    * @param object Object to write.
    */
   @SneakyThrows
-  public void writeToBucket(final String key, final Object object) {
+  public void writeToBucket(
+      final String key, final Map<String, String> metadataMap, final Object object) {
 
     // Write the object to AWS
     AmazonS3 s3Client = s3ClientService.s3Client();
@@ -44,7 +55,18 @@ public class AmazonS3ClientWriterService {
     final String unifiedResult =
         JacksonConfig.createMapper().writerWithDefaultPrettyPrinter().writeValueAsString(object);
     log.info("Storing unified result {} to AWS S3 {}.", key, bucketConfig.getName());
-    // Upload a text string as a new object.
-    s3Client.putObject(bucketConfig.getName(), key, unifiedResult);
+
+    // Upload a text string as a new object as input stream with metadata.
+    ObjectMetadata metadata = new ObjectMetadata();
+    final byte[] contentAsBytes = unifiedResult.getBytes(StandardCharsets.UTF_8);
+    metadata.setContentLength(contentAsBytes.length);
+    metadata.setContentType(S3_OBJECT_CONTENT_TYPE);
+    for (Map.Entry<String, String> entry : metadataMap.entrySet()) {
+      metadata.addUserMetadata(S3_OBJECT_CUSTOM_METADATA_PREFIX + entry.getKey(), entry.getValue());
+    }
+    try (ByteArrayInputStream contentsAsStream = new ByteArrayInputStream(contentAsBytes)) {
+      s3Client.putObject(
+          new PutObjectRequest(bucketConfig.getName(), key, contentsAsStream, metadata));
+    }
   }
 }

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/dstu2/Dstu2UnifierService.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/dstu2/Dstu2UnifierService.java
@@ -31,11 +31,6 @@ public class Dstu2UnifierService extends BaseUnifierService<Conformance, WellKno
   }
 
   @Override
-  protected String baseMetadataName() {
-    return "conformance";
-  }
-
-  @Override
   protected Query<Conformance> queryMetadata(final String url) {
     return Query.forType(Conformance.class).url(url).build();
   }

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationDstu2UnifierIntegrationTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationDstu2UnifierIntegrationTest.java
@@ -143,7 +143,8 @@ public class ApplicationDstu2UnifierIntegrationTest {
           ResourceTypeEnum.DSTU2.type(),
           EndpointTypeEnum.METADATA.type(),
           DSTU2_EXAMPLE_METADATA_ENDPOINT_1,
-          DSTU2_EXAMPLE_METADATA_ENDPOINT_2
+          DSTU2_EXAMPLE_METADATA_ENDPOINT_2,
+          "--" + Application.METADATA_ARG + "=uc-app-version=1.0.0,claims-app-version=2.0.0"
         };
     // Load DSTU2 Metadata examples and expected unified result from test resources.
     final Conformance dstu2ExampleMetadataUnifiedExpected =

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationInvalidArgumentsTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationInvalidArgumentsTest.java
@@ -34,6 +34,20 @@ public class ApplicationInvalidArgumentsTest {
     unifierApplication.run(new DefaultApplicationArguments(args));
   }
 
+  /** Test invalid metadata arg. */
+  @Test(expected = IllegalArgumentException.class)
+  @SneakyThrows
+  public void invalidMetadataArgumentsTest() {
+    final String[] args =
+        new String[] {
+          "--" + Application.METADATA_ARG + "=blah=halb,hello",
+          ResourceTypeEnum.UNKNOWN.type(),
+          EndpointTypeEnum.METADATA.type(),
+          "http://www.fhir.com/metadata"
+        };
+    unifierApplication.run(new DefaultApplicationArguments(args));
+  }
+
   /** Test arguments to test wrong number of arguments. */
   @Test(expected = IllegalArgumentException.class)
   @SneakyThrows


### PR DESCRIPTION
Use optional metadata parameters to attach metadata to generated S3 objects, added a UnifierService class to route to resource specific unifiers, changed names of generated S3 objects to match the type that is being passed as arguments.
NOTE: for ease of merging, merge this PR before https://github.com/department-of-veterans-affairs/health-apis-conformance-unifier/pull/8.