### PR TITLE
PIV-199 - centos:7

### DIFF
--- a/unifier-tests/Dockerfile
+++ b/unifier-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 COPY entrypoint.sh /
 RUN chmod 755 /entrypoint.sh


### PR DESCRIPTION
The version of `curl` shipped with `centos:latest` behaves differently than `centos:7` which is the standard across health-apis baselines.

Pin unifier-tests to `centos:7` to ensure consistent behavior, in particular the format/output of dumping headers.