### PR TITLE
Support VA Certs

### DIFF
--- a/unifier-tests/Dockerfile
+++ b/unifier-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM vasdvp/health-apis-centos:7
 
 COPY entrypoint.sh /
 RUN chmod 755 /entrypoint.sh


### PR DESCRIPTION
Update base image to `vasdvp/health-apis-centos:7` to support trusting VA Root Cert.