### PR TITLE
Task/api 825 support fhir resources 3.0.0

### DIFF
--- a/conformance-unifier/pom.xml
+++ b/conformance-unifier/pom.xml
@@ -10,8 +10,8 @@
   <artifactId>conformance-unifier</artifactId>
   <packaging>jar</packaging>
   <properties>
-    <resource.version>2.0.35</resource.version>
-    <informational.version>1.0.7</informational.version>
+    <resource.version>3.0.5</resource.version>
+    <informational.version>1.0.9-SNAPSHOT</informational.version>
     <aws-interfaces.version>1.0.1</aws-interfaces.version>
     <s3mock-junit4.version>2.1.11</s3mock-junit4.version>
     <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>

--- a/conformance-unifier/pom.xml
+++ b/conformance-unifier/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <resource.version>3.0.5</resource.version>
-    <informational.version>1.0.9-SNAPSHOT</informational.version>
+    <informational.version>1.0.9</informational.version>
     <aws-interfaces.version>1.0.1</aws-interfaces.version>
     <s3mock-junit4.version>2.1.11</s3mock-junit4.version>
     <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/Application.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/Application.java
@@ -62,7 +62,7 @@ public class Application implements ApplicationRunner {
       }
     }
 
-    /** Call unifier service. */
+    // Call unifier service.
     unifierService.unify(
         argList.get(ArgEnum.RESOURCE.ordinal()),
         argList.get(ArgEnum.ENDPOINT.ordinal()),

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/r4/R4CapabilityTransformer.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/r4/R4CapabilityTransformer.java
@@ -5,7 +5,7 @@ import gov.va.api.health.informational.r4.capability.CapabilityResourcesProperti
 import gov.va.api.health.informational.r4.capability.CapabilityStatementProperties;
 import gov.va.api.health.informational.r4.capability.CapabilityUtilities;
 import gov.va.api.health.informational.r4.capability.MetadataCapabilityStatementModeEnum;
-import gov.va.api.health.r4.api.resources.Capability;
+import gov.va.api.health.r4.api.resources.CapabilityStatement;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,41 +19,42 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor(onConstructor = @__({@Autowired}))
 public class R4CapabilityTransformer
-    extends BaseMetadataTransformer<Capability, Capability.Rest, Capability.CapabilityResource> {
+    extends BaseMetadataTransformer<
+        CapabilityStatement, CapabilityStatement.Rest, CapabilityStatement.CapabilityResource> {
 
   private final CapabilityStatementProperties capabilityStatementProperties;
 
   @Override
-  protected Capability initialInstance() {
-    return CapabilityUtilities.initializeCapabilityBuilder(
+  protected CapabilityStatement initialInstance() {
+    return CapabilityUtilities.initializeCapabilityStatementBuilder(
         MetadataCapabilityStatementModeEnum.FULL.getResourceType(),
         capabilityStatementProperties,
         new CapabilityResourcesProperties(Collections.emptyList()));
   }
 
   @Override
-  protected List<Capability.CapabilityResource> resource(Capability.Rest rest) {
+  protected List<CapabilityStatement.CapabilityResource> resource(CapabilityStatement.Rest rest) {
     return rest.resource();
   }
 
   @Override
-  protected String resourceType(Capability.CapabilityResource resource) {
+  protected String resourceType(CapabilityStatement.CapabilityResource resource) {
     return resource.type();
   }
 
   @Override
-  protected List<Capability.Rest> rest(Capability capability) {
+  protected List<CapabilityStatement.Rest> rest(CapabilityStatement capability) {
     return capability.rest();
   }
 
   @Override
   protected void setResources(
-      Capability.Rest rest, List<Capability.CapabilityResource> resourceList) {
+      CapabilityStatement.Rest rest, List<CapabilityStatement.CapabilityResource> resourceList) {
     rest.resource(resourceList);
   }
 
   @Override
-  protected boolean typeEquals(Capability.CapabilityResource resource, final String type) {
+  protected boolean typeEquals(CapabilityStatement.CapabilityResource resource, final String type) {
     return resource.type().equalsIgnoreCase(type);
   }
 }

--- a/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/r4/R4UnifierService.java
+++ b/conformance-unifier/src/main/java/gov/va/api/health/conformance/unifier/fhir/r4/R4UnifierService.java
@@ -5,13 +5,13 @@ import gov.va.api.health.conformance.unifier.client.ConformanceClient;
 import gov.va.api.health.conformance.unifier.client.Query;
 import gov.va.api.health.conformance.unifier.fhir.BaseUnifierService;
 import gov.va.api.health.r4.api.information.WellKnown;
-import gov.va.api.health.r4.api.resources.Capability;
+import gov.va.api.health.r4.api.resources.CapabilityStatement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /** Service to facilitate unification of R4 Metadata and WellKnown. */
 @Service
-public class R4UnifierService extends BaseUnifierService<Capability, WellKnown> {
+public class R4UnifierService extends BaseUnifierService<CapabilityStatement, WellKnown> {
 
   /**
    * Construct a unifier service for R4 type resources.
@@ -31,8 +31,8 @@ public class R4UnifierService extends BaseUnifierService<Capability, WellKnown> 
   }
 
   @Override
-  protected Query<Capability> queryMetadata(final String url) {
-    return Query.forType(Capability.class).url(url).build();
+  protected Query<CapabilityStatement> queryMetadata(final String url) {
+    return Query.forType(CapabilityStatement.class).url(url).build();
   }
 
   @Override

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationDstu2UnifierIntegrationTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationDstu2UnifierIntegrationTest.java
@@ -45,9 +45,8 @@ import org.springframework.web.client.RestTemplate;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(
-  classes = Application.class,
-  initializers = ConfigFileApplicationContextInitializer.class
-)
+    classes = Application.class,
+    initializers = ConfigFileApplicationContextInitializer.class)
 public class ApplicationDstu2UnifierIntegrationTest {
 
   /** Class rule for Mock Amazon S3. */

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationInvalidArgumentsTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationInvalidArgumentsTest.java
@@ -14,9 +14,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 /** Test various scenarios of running application with invalid arguments. */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(
-  classes = Application.class,
-  initializers = ConfigFileApplicationContextInitializer.class
-)
+    classes = Application.class,
+    initializers = ConfigFileApplicationContextInitializer.class)
 public class ApplicationInvalidArgumentsTest {
 
   @Autowired Application unifierApplication;

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationR4UnifierIntegrationTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationR4UnifierIntegrationTest.java
@@ -17,7 +17,7 @@ import gov.va.api.health.conformance.unifier.fhir.EndpointTypeEnum;
 import gov.va.api.health.conformance.unifier.fhir.ResourceTypeEnum;
 import gov.va.api.health.informational.r4.capability.CapabilityStatementProperties;
 import gov.va.api.health.r4.api.information.WellKnown;
-import gov.va.api.health.r4.api.resources.Capability;
+import gov.va.api.health.r4.api.resources.CapabilityStatement;
 import java.net.URI;
 import java.nio.file.Paths;
 import lombok.SneakyThrows;
@@ -45,9 +45,8 @@ import org.springframework.web.client.RestTemplate;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(
-  classes = Application.class,
-  initializers = ConfigFileApplicationContextInitializer.class
-)
+    classes = Application.class,
+    initializers = ConfigFileApplicationContextInitializer.class)
 public class ApplicationR4UnifierIntegrationTest {
 
   /** Class rule for Mock Amazon S3. */
@@ -108,14 +107,14 @@ public class ApplicationR4UnifierIntegrationTest {
           R4_EXAMPLE_METADATA_ENDPOINT_1
         };
     // Load R4 Metadata examples from test resources.
-    final Capability r4Example1Metadata =
+    final CapabilityStatement r4Example1Metadata =
         mapper.readValue(
             Paths.get("src", "test", "resources", "r4_example_metadata_1.json").toFile(),
-            Capability.class);
-    final Capability r4Example2Metadata =
+            CapabilityStatement.class);
+    final CapabilityStatement r4Example2Metadata =
         mapper.readValue(
             Paths.get("src", "test", "resources", "r4_example_metadata_2.json").toFile(),
-            Capability.class);
+            CapabilityStatement.class);
     // Configure mock server to respond with appropriate example per metadata endpoint.
     mockServer
         .expect(ExpectedCount.manyTimes(), requestTo(new URI(R4_EXAMPLE_METADATA_ENDPOINT_1)))
@@ -150,18 +149,18 @@ public class ApplicationR4UnifierIntegrationTest {
           R4_EXAMPLE_METADATA_ENDPOINT_2
         };
     // Load R4 Metadata examples and expected unified result from test resources.
-    final Capability r4ExampleMetadataUnifiedExpected =
+    final CapabilityStatement r4ExampleMetadataUnifiedExpected =
         mapper.readValue(
             Paths.get("src", "test", "resources", "r4_example_metadata_unified.json").toFile(),
-            Capability.class);
-    final Capability r4Example1Metadata =
+            CapabilityStatement.class);
+    final CapabilityStatement r4Example1Metadata =
         mapper.readValue(
             Paths.get("src", "test", "resources", "r4_example_metadata_1.json").toFile(),
-            Capability.class);
-    final Capability r4Example2Metadata =
+            CapabilityStatement.class);
+    final CapabilityStatement r4Example2Metadata =
         mapper.readValue(
             Paths.get("src", "test", "resources", "r4_example_metadata_2.json").toFile(),
-            Capability.class);
+            CapabilityStatement.class);
     // Configure mock server to respond with appropriate example per metadata endpoint.
     mockServer
         .expect(ExpectedCount.once(), requestTo(new URI(R4_EXAMPLE_METADATA_ENDPOINT_1)))
@@ -180,10 +179,10 @@ public class ApplicationR4UnifierIntegrationTest {
     // Run the unifier application using the R4 Metadata command line arguments.
     unifierApplication.run(new DefaultApplicationArguments(r4MetadataCommandLineArgs));
     // Obtain a unified R4 Metadata object via the mocked Amazon S3.
-    final Capability s3UnifiedMetadata =
+    final CapabilityStatement s3UnifiedMetadata =
         mapper.readValue(
             AmazonS3BucketUtilities.getResultFromS3(s3Client, amazonS3BucketConfig.getName()),
-            Capability.class);
+            CapabilityStatement.class);
     // Verify the result obtained from the mocked Amazon S3 matches the expected object.
     // NOTE: the publication date is set to current time when bean created so override the expected
     // publication date with the current time value.

--- a/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationStu3UnifierIntegrationTest.java
+++ b/conformance-unifier/src/test/java/gov/va/api/health/conformance/unifier/ApplicationStu3UnifierIntegrationTest.java
@@ -45,9 +45,8 @@ import org.springframework.web.client.RestTemplate;
  */
 @RunWith(SpringRunner.class)
 @ContextConfiguration(
-  classes = Application.class,
-  initializers = ConfigFileApplicationContextInitializer.class
-)
+    classes = Application.class,
+    initializers = ConfigFileApplicationContextInitializer.class)
 public class ApplicationStu3UnifierIntegrationTest {
 
   /** Class rule for Mock Amazon S3. */

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>4.0.6</version>
+    <version>5.0.5</version>
   </parent>
   <artifactId>conformance-unifier-parent</artifactId>
   <version>1.0.29-SNAPSHOT</version>


### PR DESCRIPTION
Refactor Capability to Capability Statement to support `fhir-resources` R4 major version upgrade.
Related story: https://vajira.max.gov/browse/API-825